### PR TITLE
Fix double login issue

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs24/service/UserService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs24/service/UserService.java
@@ -52,6 +52,11 @@ public class UserService {
   public User loginUser(String spotifyUserId, SpotifyJWT spotifyJWT) {
       User user = userRepository.findBySpotifyUserId(spotifyUserId);
 
+      // remove old spotifyJWT if already exits (e.g. second login attempt without log out)
+      if (user.getSpotifyJWT() != null) {
+          User loggedOutUser = logoutUser(user);
+      }
+
       // save the spotifyJWT first
       spotifyJWT.setUser(user);
       spotifyJWT = spotifyJWTRepository.save(spotifyJWT);


### PR DESCRIPTION
Log out user at login if he wasn't logged out properly before.

Alternative of just throwing an error is unsatisfactory, as the frontend might not have the sessionToken for that session (e.g. on a different device or so).